### PR TITLE
feat: Add Win95 notes app to homepage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,6 +84,14 @@ const App = () => {
       githubUrl: "https://github.com/mattsilv/silv-learn",
       category: "app",
     },
+    {
+      id: 10,
+      title: "Win95 notes",
+      description:
+        "A simple app to pass someone a note in the old Windows 95 Notepad style interface, the text of the note is passed in the URL with a very simplistic cipher.",
+      link: "https://win95.silv.app/?t=filename.txt&c=khoor%2520zruog",
+      category: "app",
+    },
   ];
 
   return (


### PR DESCRIPTION
Adds the Win95 notes app to the list of applications on the homepage.

The app is described as a simple way to pass notes using a Windows 95 Notepad style interface, with the note content passed via a URL cipher.